### PR TITLE
handle nested dict and int indices correctly

### DIFF
--- a/flamyngo/views.py
+++ b/flamyngo/views.py
@@ -162,7 +162,7 @@ def query():
     cname = request.args.get("collection").split(":")[0]
     settings = CSETTINGS[cname]
     search_string = request.args.get("search_string")
-    projection = [t[0] for t in settings["summary"]]
+    projection = [t[0].split(".")[0] for t in settings["summary"]]
     fields = None
     results = None
     mapped_names = None
@@ -329,7 +329,7 @@ def _get_val(k, d, processing_func):
         for t in toks[1:]:
             try:
                 val = val[t]
-            except KeyError:
+            except TypeError as ex:
                 # Handle integer indices
                 val = val[int(t)]
         val = process(val, processing_func)


### PR DESCRIPTION
## Summary

The `_get_val()` method was designed to descend into nested dictionaries containing list of data. However, the existing code fails to descend into the dictionary or to catch the exception of taking a key in str to a dict as an int index of a list. This commit fix both errors so that nested entries can be descended conveniently as designed.

* Feature 1
https://github.com/materialsvirtuallab/flamyngo/blob/00d48d20568dc2dab3bf1fcff5135031c070e516/flamyngo/views.py#L165
Line 165 extracts the desired data from Mongodb database. However, the `projection` did not consider descending entries, e.g., "entry.entry1.entry2", so the extracted data does not have the requested descending data asked by the `Summary` in config.yaml to display.

* Feature 2
https://github.com/materialsvirtuallab/flamyngo/blob/00d48d20568dc2dab3bf1fcff5135031c070e516/flamyngo/views.py#L332-L334
Line 332 catches the exception and then transfer the str `t` to an int so that values in list can also be conveniently extracted. However, the correct exception is `TypeError` instead of `KeyError`, as the code here is trying to extract an object with str index `t` from a list, while the index `t` should have had a type of int.

Both errors are fixed, and now data in nested dictionaries can be easily extracted.